### PR TITLE
Clean message handling

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,6 @@
-use crate::connection::{Command, Connection, Message, MessageBody, Nickname, ReplyType, Username};
+use crate::connection::{
+    Command, Connection, Message, MessageBody, MessageParams, Nickname, ReplyType, Username,
+};
 use std::io;
 use std::net;
 
@@ -67,7 +69,7 @@ impl Client {
         }
     }
 
-    fn handle_reply(&self, _reply_type: ReplyType, _reply_body: String) {}
+    fn handle_reply(&self, _reply_type: ReplyType, _reply_body: MessageParams) {}
 
     pub fn send_command_raw(&mut self, raw_command: String) -> io::Result<()> {
         self.connection.send_command_raw(raw_command)

--- a/src/connection/message/command.rs
+++ b/src/connection/message/command.rs
@@ -450,10 +450,19 @@ impl FromStr for Command {
                 from: None,
                 to: None,
             }),
-            ("PING", 1) => Ok(Command::Ping {
-                from: None,
-                to: Some(args[0].parse()?),
-            }),
+            ("PING", 1) => {
+                if raw_args.starts_with(':') {
+                    Ok(Command::Ping {
+                        from: Some(args[0].parse()?),
+                        to: None,
+                    })
+                } else {
+                    Ok(Command::Ping {
+                        from: None,
+                        to: Some(args[0].parse()?),
+                    })
+                }
+            }
             ("PING", 2) => Ok(Command::Ping {
                 from: Some(args[0].parse()?),
                 to: Some(args[1].parse()?),
@@ -667,17 +676,24 @@ mod tests {
         );
         assert_eq!(
             Ok(Command::Ping {
-                to: Some("myserver".parse().unwrap()),
-                from: None
+                to: None,
+                from: Some("spudly".parse().unwrap())
             }),
-            "PING myserver".parse::<Command>()
+            "PING :spudly".parse::<Command>()
         );
         assert_eq!(
             Ok(Command::Ping {
-                to: Some("myserver".parse().unwrap()),
-                from: Some("me".parse().unwrap())
+                to: Some("irc.example.com".parse().unwrap()),
+                from: None
             }),
-            "PING me myserver".parse::<Command>()
+            "PING irc.example.com".parse::<Command>()
+        );
+        assert_eq!(
+            Ok(Command::Ping {
+                to: Some("irc.example.com".parse().unwrap()),
+                from: Some("spudly".parse().unwrap())
+            }),
+            "PING spudly irc.example.com".parse::<Command>()
         );
         assert!("PING a b c".parse::<Command>().is_err());
     }

--- a/src/connection/message/command.rs
+++ b/src/connection/message/command.rs
@@ -1,7 +1,7 @@
 use super::super::entity::{
     Channel, ChannelKey, Nickname, Recipient, Sender, Servername, Username,
 };
-use super::super::syntax::{KeywordList, ServerMask, StatsQuery, TargetMask};
+use super::super::syntax::{KeywordList, ServerMask, StatsQuery};
 use super::{MessageParams, ParseError};
 use std::result::Result;
 use std::str::FromStr;
@@ -30,7 +30,7 @@ pub enum Command {
     },
     Service {
         nickname: Nickname,
-        distribution: TargetMask,
+        distribution: ServerMask,
         info: String,
     },
     Quit {
@@ -60,11 +60,11 @@ pub enum Command {
     },
     Names {
         channels: KeywordList<Channel>,
-        target: Option<Servername>,
+        target: Option<ServerMask>,
     },
     List {
         channels: KeywordList<Channel>,
-        target: Option<Servername>,
+        target: Option<ServerMask>,
     },
     Invite {
         nickname: Nickname,
@@ -88,14 +88,14 @@ pub enum Command {
 
     // Server queries and commands
     Motd {
-        target: Option<Servername>,
+        target: Option<ServerMask>,
     },
     LUsers {
         mask: Option<ServerMask>,
         target: Option<Servername>,
     },
     Version {
-        target: Option<Servername>,
+        target: Option<ServerMask>,
     },
     Stats {
         query: Option<StatsQuery>,
@@ -103,10 +103,10 @@ pub enum Command {
     },
     Links {
         mask: Option<ServerMask>,
-        target: Option<Servername>,
+        target: Option<ServerMask>,
     },
     Time {
-        target: Option<Servername>,
+        target: Option<ServerMask>,
     },
     Connect {
         target: Servername,
@@ -114,13 +114,13 @@ pub enum Command {
         remote: Option<Servername>,
     },
     Trace {
-        target: Option<Servername>,
+        target: Option<String>,
     }, // TODO: add nickname
     Admin {
-        target: Option<Servername>,
+        target: Option<String>,
     }, // TODO: add nickname
     Info {
-        target: Option<Servername>,
+        target: Option<String>,
     }, // TODO: add nickname
 
     // Service query and commands
@@ -135,15 +135,15 @@ pub enum Command {
 
     // User based queries
     Who {
-        mask: String,
+        mask: Option<String>,
         op_only: bool,
     },
     WhoIs {
         mask: String,
-        target: Option<Servername>,
+        target: Option<ServerMask>,
     },
     WhoWas {
-        targets: KeywordList<Nickname>,
+        nicknames: KeywordList<Nickname>,
         count: Option<u16>,
         target: Option<ServerMask>,
     },
@@ -240,7 +240,7 @@ impl FromStr for Command {
             ("SERVICE", 6) => Ok(Command::Service {
                 nickname: args[0].parse()?,
                 distribution: args[2].parse()?,
-                info: args[4].to_owned(),
+                info: args[5].to_owned(),
             }),
             ("QUIT", 0) => Ok(Command::Quit { message: None }),
             ("QUIT", 1) => Ok(Command::Quit {
@@ -282,6 +282,10 @@ impl FromStr for Command {
             ("TOPIC", 2) => Ok(Command::Topic {
                 channel: args[0].parse()?,
                 topic: Some(args[1].to_string()),
+            }),
+            ("NAMES", 0) => Ok(Command::Names {
+                channels: KeywordList::new(),
+                target: None,
             }),
             ("NAMES", 1) => Ok(Command::Names {
                 channels: args[0].parse()?,
@@ -385,15 +389,15 @@ impl FromStr for Command {
             }),
             ("TRACE", 0) => Ok(Command::Trace { target: None }),
             ("TRACE", 1) => Ok(Command::Trace {
-                target: Some(args[0].parse()?),
+                target: Some(args[0].to_string()),
             }),
             ("ADMIN", 0) => Ok(Command::Admin { target: None }),
             ("ADMIN", 1) => Ok(Command::Admin {
-                target: Some(args[0].parse()?),
+                target: Some(args[0].to_string()),
             }),
             ("INFO", 0) => Ok(Command::Info { target: None }),
             ("INFO", 1) => Ok(Command::Info {
-                target: Some(args[0].parse()?),
+                target: Some(args[0].to_string()),
             }),
             ("SERVLIST", 0) => Ok(Command::ServList {
                 mask: None,
@@ -411,12 +415,16 @@ impl FromStr for Command {
                 recipient: args[0].parse()?,
                 message: args[1].to_string(),
             }),
+            ("WHO", 0) => Ok(Command::Who {
+                mask: None,
+                op_only: false,
+            }),
             ("WHO", 1) => Ok(Command::Who {
-                mask: args[0].to_string(),
+                mask: Some(args[0].to_string()),
                 op_only: false,
             }),
             ("WHO", 2) => Ok(Command::Who {
-                mask: args[0].to_string(),
+                mask: Some(args[0].to_string()),
                 op_only: args[1] == "o" || return Err(ParseError::new("Command")),
             }),
             ("WHOIS", 1) => Ok(Command::WhoIs {
@@ -424,21 +432,21 @@ impl FromStr for Command {
                 target: None,
             }),
             ("WHOIS", 2) => Ok(Command::WhoIs {
-                mask: args[0].to_string(),
-                target: Some(args[1].parse()?),
+                mask: args[1].to_string(),
+                target: Some(args[0].parse()?),
             }),
             ("WHOWAS", 1) => Ok(Command::WhoWas {
-                targets: args[0].parse()?,
+                nicknames: args[0].parse()?,
                 count: None,
                 target: None,
             }),
             ("WHOWAS", 2) => Ok(Command::WhoWas {
-                targets: args[0].parse()?,
+                nicknames: args[0].parse()?,
                 count: Some(args[1].parse().map_err(|_| ParseError::new("Command"))?),
                 target: None,
             }),
             ("WHOWAS", 3) => Ok(Command::WhoWas {
-                targets: args[0].parse()?,
+                nicknames: args[0].parse()?,
                 count: Some(args[1].parse().map_err(|_| ParseError::new("Command"))?),
                 target: Some(args[2].parse()?),
             }),
@@ -507,13 +515,21 @@ impl FromStr for Command {
             ("WALLOPS", 1) => Ok(Command::WallOps {
                 message: args[0].to_string(),
             }),
-            ("USERHOST", 1) => Ok(Command::UserHost {
-                nicknames: args[0].parse()?,
+            ("USERHOST", 1..=15) => Ok(Command::UserHost {
+                nicknames: args
+                    .into_iter()
+                    .collect::<Vec<String>>()
+                    .join(",")
+                    .parse()?,
             }),
-            ("ISON", 1) => Ok(Command::IsOn {
-                nicknames: args[0].parse()?,
+            ("ISON", 1..=15) => Ok(Command::IsOn {
+                nicknames: args
+                    .into_iter()
+                    .collect::<Vec<String>>()
+                    .join(",")
+                    .parse()?,
             }),
-            (_, _) => Err(ParseError::new("Command")),
+            _ => Err(ParseError::new("Command")),
         }
     }
 }
@@ -521,200 +537,1555 @@ impl FromStr for Command {
 impl From<Command> for String {
     fn from(command: Command) -> String {
         match command {
-            Command::Pass { password } => format!("PASS {}", password),
-            Command::Nick { nickname } => format!("NICK {}", String::from(nickname)),
+            Command::Pass { password } => {
+                MessageParams::from(vec![password]).to_string_with_prefix("PASS")
+            }
+            Command::Nick { nickname } => {
+                MessageParams::from(vec![String::from(nickname)]).to_string_with_prefix("NICK")
+            }
             Command::User {
                 username,
                 mode,
                 realname,
-            } => format!("USER {} {} * :{}", String::from(username), mode, realname),
-            Command::Ping {
-                to: Some(to),
-                from: Some(from),
-            } => format!("PING {} {}", String::from(from), String::from(to)),
-            Command::Ping {
-                to: Some(to),
-                from: None,
-            } => format!("PING {}", String::from(to)),
-            Command::Ping {
-                to: None,
-                from: None,
-            } => "PING".to_string(),
-            Command::Pong { to: Some(to), from } => {
-                format!("PONG {} {}", String::from(from), String::from(to))
+            } => MessageParams::from(vec![
+                String::from(username),
+                mode.to_string(),
+                "*".to_string(),
+                realname,
+            ])
+            .to_string_with_prefix("USER"),
+            Command::Oper { user, password } => {
+                MessageParams::from(vec![String::from(user), password])
+                    .to_string_with_prefix("OPER")
             }
-            Command::Pong { to: None, from } => format!("PONG {}", String::from(from)),
-            _ => "".to_string(),
+            Command::UserMode { nickname, modes } => {
+                MessageParams::from(vec![String::from(nickname), modes])
+                    .to_string_with_prefix("MODE")
+            }
+            Command::Service {
+                nickname,
+                distribution,
+                info,
+            } => MessageParams::from(vec![
+                String::from(nickname),
+                "".to_string(),
+                String::from(distribution),
+                "0".to_string(),
+                "0".to_string(),
+                info,
+            ])
+            .to_string_with_prefix("SERVICE"),
+            Command::Quit { message: None } => "QUIT".to_string(),
+            Command::Quit {
+                message: Some(message),
+            } => MessageParams::from(vec![String::from(message)]).to_string_with_prefix("QUIT"),
+            Command::SQuit { server, comment } => {
+                MessageParams::from(vec![String::from(server), comment])
+                    .to_string_with_prefix("SQUIT")
+            }
+
+            // Channel operations
+            Command::Join { channels, .. } if channels.len() == 0 => "JOIN 0".to_string(),
+            Command::Join { channels, keys } if keys.len() == 0 => {
+                MessageParams::from(vec![String::from(channels)]).to_string_with_prefix("JOIN")
+            }
+            Command::Join { channels, keys } => {
+                MessageParams::from(vec![String::from(channels), String::from(keys)])
+                    .to_string_with_prefix("JOIN")
+            }
+            Command::Part {
+                channels,
+                message: None,
+            } => MessageParams::from(vec![String::from(channels)]).to_string_with_prefix("PART"),
+            Command::Part {
+                channels,
+                message: Some(message),
+            } => MessageParams::from(vec![String::from(channels), message])
+                .to_string_with_prefix("PART"),
+            Command::ChannelMode { channel, modes } => {
+                format!("MODE {} {}", String::from(channel), modes)
+            }
+            Command::Topic {
+                channel,
+                topic: None,
+            } => MessageParams::from(vec![String::from(channel)]).to_string_with_prefix("TOPIC"),
+            Command::Topic {
+                channel,
+                topic: Some(topic),
+            } => MessageParams::from(vec![String::from(channel), topic])
+                .to_string_with_prefix("TOPIC"),
+            Command::Names {
+                channels,
+                target: None,
+            } if channels.len() == 0 => "NAMES".to_string(),
+            Command::Names {
+                channels,
+                target: None,
+            } => MessageParams::from(vec![String::from(channels)]).to_string_with_prefix("NAMES"),
+            Command::Names {
+                channels,
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(channels), String::from(target)])
+                .to_string_with_prefix("NAMES"),
+            Command::List {
+                channels,
+                target: None,
+            } if channels.len() == 0 => "LIST".to_string(),
+            Command::List {
+                channels,
+                target: None,
+            } => MessageParams::from(vec![String::from(channels)]).to_string_with_prefix("LIST"),
+            Command::List {
+                channels,
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(channels), String::from(target)])
+                .to_string_with_prefix("LIST"),
+            Command::Invite { nickname, channel } => {
+                MessageParams::from(vec![String::from(nickname), String::from(channel)])
+                    .to_string_with_prefix("INVITE")
+            }
+            Command::Kick {
+                channels,
+                users,
+                comment: None,
+            } => MessageParams::from(vec![String::from(channels), String::from(users)])
+                .to_string_with_prefix("KICK"),
+            Command::Kick {
+                channels,
+                users,
+                comment: Some(comment),
+            } => MessageParams::from(vec![String::from(channels), String::from(users), comment])
+                .to_string_with_prefix("KICK"),
+
+            // Sending messages
+            Command::Privmsg {
+                recipients,
+                message,
+            } => MessageParams::from(vec![String::from(recipients), message])
+                .to_string_with_prefix("PRIVMSG"),
+            Command::Notice {
+                recipients,
+                message,
+            } => MessageParams::from(vec![String::from(recipients), message])
+                .to_string_with_prefix("NOTICE"),
+
+            // Server queries and commands
+            Command::Motd { target: None } => "MOTD".to_string(),
+            Command::Motd {
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("MOTD"),
+            Command::LUsers {
+                mask: None,
+                target: None,
+            } => "LUSERS".to_string(),
+            Command::LUsers {
+                mask: None,
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("LUSERS"),
+            Command::LUsers {
+                mask: Some(mask),
+                target: None,
+            } => MessageParams::from(vec![String::from(mask)]).to_string_with_prefix("LUSERS"),
+            Command::LUsers {
+                mask: Some(mask),
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(mask), String::from(target)])
+                .to_string_with_prefix("LUSERS"),
+            Command::Version { target: None } => "VERSION".to_string(),
+            Command::Version {
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("VERSION"),
+            Command::Stats { query: None, .. } => "STATS".to_string(),
+            Command::Stats {
+                query: Some(query),
+                target: None,
+            } => MessageParams::from(vec![String::from(query)]).to_string_with_prefix("STATS"),
+            Command::Stats {
+                query: Some(query),
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(query), String::from(target)])
+                .to_string_with_prefix("STATS"),
+            Command::Links {
+                mask: None,
+                target: None,
+            } => "LINKS".to_string(),
+            Command::Links {
+                mask: Some(mask),
+                target: None,
+            } => MessageParams::from(vec![String::from(mask)]).to_string_with_prefix("LINKS"),
+            Command::Links {
+                mask: None,
+                target: Some(target),
+            } => MessageParams::from(vec!["*".to_string(), String::from(target)])
+                .to_string_with_prefix("LINKS"),
+            Command::Links {
+                mask: Some(mask),
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target), String::from(mask)])
+                .to_string_with_prefix("LINKS"),
+            Command::Time { target: None } => "TIME".to_string(),
+            Command::Time {
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("TIME"),
+            Command::Connect {
+                target,
+                port,
+                remote: None,
+            } => MessageParams::from(vec![String::from(target), port.to_string()])
+                .to_string_with_prefix("CONNECT"),
+            Command::Connect {
+                target,
+                port,
+                remote: Some(remote),
+            } => MessageParams::from(vec![
+                String::from(target),
+                port.to_string(),
+                String::from(remote),
+            ])
+            .to_string_with_prefix("CONNECT"),
+            Command::Trace { target: None } => "TRACE".to_string(),
+            Command::Trace {
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("TRACE"),
+            Command::Admin { target: None } => "ADMIN".to_string(),
+            Command::Admin {
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("ADMIN"),
+            Command::Info { target: None } => "INFO".to_string(),
+            Command::Info {
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("INFO"),
+
+            // Service query and commands
+            Command::ServList {
+                mask: None,
+                service_type: None,
+            } => "SERVLIST".to_string(),
+            Command::ServList {
+                mask: Some(mask),
+                service_type: None,
+            } => MessageParams::from(vec![String::from(mask)]).to_string_with_prefix("SERVLIST"),
+            Command::ServList {
+                mask: None,
+                service_type: Some(service_type),
+            } => MessageParams::from(vec![String::from(service_type)])
+                .to_string_with_prefix("SERVLIST"),
+            Command::ServList {
+                mask: Some(mask),
+                service_type: Some(service_type),
+            } => MessageParams::from(vec![String::from(mask), service_type])
+                .to_string_with_prefix("SERVLIST"),
+            Command::SQuery { recipient, message } => {
+                MessageParams::from(vec![String::from(recipient), message])
+                    .to_string_with_prefix("SQUERY")
+            }
+
+            // User based queries
+            Command::Who { mask: None, .. } => "WHO".to_string(),
+            Command::Who {
+                mask: Some(mask),
+                op_only: false,
+            } => MessageParams::from(vec![String::from(mask)]).to_string_with_prefix("WHO"),
+            Command::Who {
+                mask: Some(mask),
+                op_only: true,
+            } => MessageParams::from(vec![String::from(mask), "o".to_string()])
+                .to_string_with_prefix("WHO"),
+            Command::WhoIs { mask, target: None } => {
+                MessageParams::from(vec![String::from(mask)]).to_string_with_prefix("WHOIS")
+            }
+            Command::WhoIs {
+                mask,
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target), String::from(mask)])
+                .to_string_with_prefix("WHOIS"),
+            Command::WhoWas {
+                nicknames,
+                count: None,
+                target: None,
+            } => MessageParams::from(vec![String::from(nicknames)]).to_string_with_prefix("WHOWAS"),
+            Command::WhoWas {
+                nicknames,
+                count: None,
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(nicknames), String::from(target)])
+                .to_string_with_prefix("WHOWAS"),
+            Command::WhoWas {
+                nicknames,
+                count: Some(count),
+                target: None,
+            } => MessageParams::from(vec![String::from(nicknames), count.to_string()])
+                .to_string_with_prefix("WHOWAS"),
+            Command::WhoWas {
+                nicknames,
+                count: Some(count),
+                target: Some(target),
+            } => MessageParams::from(vec![
+                String::from(nicknames),
+                count.to_string(),
+                String::from(target),
+            ])
+            .to_string_with_prefix("WHOWAS"),
+
+            // Miscellaneous messages
+            Command::Kill { nickname, comment } => {
+                MessageParams::from(vec![String::from(nickname), comment])
+                    .to_string_with_prefix("KILL")
+            }
+            Command::Ping {
+                from: None,
+                to: None,
+            } => "PING".to_string(),
+            Command::Ping {
+                from: None,
+                to: Some(to),
+            } => MessageParams::from(vec![String::from(to)]).to_string_with_prefix("PING"),
+            Command::Ping {
+                from: Some(from),
+                to: None,
+            } => format!("PING :{}", String::from(from)),
+            Command::Ping {
+                from: Some(from),
+                to: Some(to),
+            } => MessageParams::from(vec![String::from(from), String::from(to)])
+                .to_string_with_prefix("PING"),
+            Command::Pong { from, to: None } => {
+                MessageParams::from(vec![String::from(from)]).to_string_with_prefix("PONG")
+            }
+            Command::Pong { from, to: Some(to) } => {
+                MessageParams::from(vec![String::from(from), String::from(to)])
+                    .to_string_with_prefix("PONG")
+            }
+            Command::Error { message } => {
+                MessageParams::from(vec![String::from(message)]).to_string_with_prefix("ERROR")
+            }
+
+            // Optional features
+            Command::Away { message: None } => "AWAY".to_string(),
+            Command::Away {
+                message: Some(message),
+            } => MessageParams::from(vec![String::from(message)]).to_string_with_prefix("AWAY"),
+            Command::Rehash => "REHASH".to_string(),
+            Command::Die => "DIE".to_string(),
+            Command::Restart => "RESTART".to_string(),
+            Command::Summon {
+                user,
+                target: None,
+                channel: None,
+            } => MessageParams::from(vec![String::from(user)]).to_string_with_prefix("SUMMON"),
+            Command::Summon {
+                user,
+                target: None,
+                channel: Some(channel),
+            } => MessageParams::from(vec![String::from(user), String::from(channel)])
+                .to_string_with_prefix("SUMMON"),
+            Command::Summon {
+                user,
+                target: Some(target),
+                channel: None,
+            } => MessageParams::from(vec![String::from(user), String::from(target)])
+                .to_string_with_prefix("SUMMON"),
+            Command::Summon {
+                user,
+                target: Some(target),
+                channel: Some(channel),
+            } => MessageParams::from(vec![
+                String::from(user),
+                String::from(target),
+                String::from(channel),
+            ])
+            .to_string_with_prefix("SUMMON"),
+            Command::Users { target: None } => "USERS".to_string(),
+            Command::Users {
+                target: Some(target),
+            } => MessageParams::from(vec![String::from(target)]).to_string_with_prefix("USERS"),
+            Command::WallOps { message } => {
+                MessageParams::from(vec![String::from(message)]).to_string_with_prefix("WALLOPS")
+            }
+            Command::UserHost { nicknames } => MessageParams::from(vec![String::from(nicknames)])
+                .to_string_with_prefix("USERHOST")
+                .replace(',', " "),
+            Command::IsOn { nicknames } => MessageParams::from(vec![String::from(nicknames)])
+                .to_string_with_prefix("ISON")
+                .replace(',', " "),
         }
     }
 }
 
+/// The tests in this section, and their annotations, are copied verbatim from the examples in RFC 2812.
 #[cfg(test)]
 mod tests {
+    use super::super::{Message, MessageBody};
     use super::*;
 
-    #[test]
-    fn string_from_pass() {
+    fn assert_roundtrip(raw: &str, sender: Option<Sender>, command: Command) {
+        let parsed_message = raw.parse::<Message>();
         assert_eq!(
-            "PASS mysecretpass".to_string(),
-            String::from(Command::Pass {
-                password: "mysecretpass".to_string(),
+            Ok(Message {
+                sender,
+                body: MessageBody::Command(command)
             }),
+            parsed_message
+        );
+        assert_eq!(raw.to_string(), String::from(parsed_message.unwrap()),);
+    }
+
+    #[test]
+    fn connection_registration_password() {
+        assert_roundtrip(
+            "PASS secretpasswordhere",
+            None,
+            Command::Pass {
+                password: "secretpasswordhere".to_string(),
+            },
         );
     }
 
     #[test]
-    fn string_from_nick() {
-        assert_eq!(
-            "NICK potato".to_string(),
-            String::from(Command::Nick {
-                nickname: "potato".parse().unwrap(),
-            }),
+    fn connection_registration_nick() {
+        // Introducing new nick "Wiz" if session is still unregistered, or user changing his nickname to "Wiz"
+        assert_roundtrip(
+            "NICK Wiz",
+            None,
+            Command::Nick {
+                nickname: "Wiz".parse().unwrap(),
+            },
+        );
+        // Server telling that WiZ changed his nickname to Kilroy.
+        assert_roundtrip(
+            ":WiZ!jto@tolsun.oulu.fi NICK Kilroy",
+            Some("WiZ!jto@tolsun.oulu.fi".parse().unwrap()),
+            Command::Nick {
+                nickname: "Kilroy".parse().unwrap(),
+            },
         );
     }
 
     #[test]
-    fn string_from_user() {
-        assert_eq!(
-            "USER pjohnson 0 * :Potato Johnson".to_string(),
-            String::from(Command::User {
-                username: "pjohnson".parse().unwrap(),
+    fn connection_registration_user() {
+        // User registering themselves with a username of "guest" and real name "Ronnie Reagan".
+        assert_roundtrip(
+            "USER guest 0 * :Ronnie Reagan",
+            None,
+            Command::User {
+                username: "guest".parse().unwrap(),
                 mode: 0,
-                realname: "Potato Johnson".to_string(),
-            }),
+                realname: "Ronnie Reagan".to_string(),
+            },
+        );
+        // User registering themselves with a username of "guest" and real name "Ronnie Reagan", and asking to be set invisible.
+        assert_roundtrip(
+            "USER guest 8 * :Ronnie Reagan",
+            None,
+            Command::User {
+                username: "guest".parse().unwrap(),
+                mode: 8,
+                realname: "Ronnie Reagan".to_string(),
+            },
         );
     }
 
     #[test]
-    fn string_from_ping() {
-        assert_eq!(
-            "PING".to_string(),
-            String::from(Command::Ping {
+    fn connection_registration_oper() {
+        // Attempt to register as an operator using a username of "foo" and "bar" as the password.
+        assert_roundtrip(
+            "OPER foo bar",
+            None,
+            Command::Oper {
+                user: "foo".parse().unwrap(),
+                password: "bar".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn connection_registration_user_mode() {
+        // Command by WiZ to turn off reception of WALLOPS messages.
+        assert_roundtrip(
+            "MODE WiZ -w",
+            None,
+            Command::UserMode {
+                nickname: "WiZ".parse().unwrap(),
+                modes: "-w".to_string(),
+            },
+        );
+        // Command from Angel to make herself invisible.
+        assert_roundtrip(
+            "MODE Angel +i",
+            None,
+            Command::UserMode {
+                nickname: "Angel".parse().unwrap(),
+                modes: "+i".to_string(),
+            },
+        );
+        // WiZ 'deopping' (removing operator status).
+        assert_roundtrip(
+            "MODE WiZ -o",
+            None,
+            Command::UserMode {
+                nickname: "WiZ".parse().unwrap(),
+                modes: "-o".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn connection_registration_service() {
+        // Service registering itself with a name of "dict".  This service will only be available on servers which name matches "*.fr".
+        assert_roundtrip(
+            "SERVICE dict * *.fr 0 0 :French Dictionary",
+            None,
+            Command::Service {
+                nickname: "dict".parse().unwrap(),
+                distribution: "*.fr".parse().unwrap(),
+                info: "French Dictionary".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn connection_registration_quit() {
+        // Preferred message format.
+        assert_roundtrip(
+            "QUIT :Gone to have lunch",
+            None,
+            Command::Quit {
+                message: Some("Gone to have lunch".to_string()),
+            },
+        );
+        // User syrk has quit IRC to have lunch.
+        assert_roundtrip(
+            ":syrk!kalt@millennium.stealth.net QUIT :Gone to have lunch",
+            Some("syrk!kalt@millennium.stealth.net".parse().unwrap()),
+            Command::Quit {
+                message: Some("Gone to have lunch".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn connection_registration_squit() {
+        // Command to uplink of the server tolson.oulu.fi to terminate its connection with comment "Bad Link".
+        assert_roundtrip(
+            "SQUIT tolsun.oulu.fi :Bad Link ?",
+            None,
+            Command::SQuit {
+                server: "tolsun.oulu.fi".parse().unwrap(),
+                comment: "Bad Link ?".to_string(),
+            },
+        );
+        // Command from Trillian from to disconnect "cm22.eng.umd.edu" from the net with comment "Server out of control".
+        assert_roundtrip(
+            ":Trillian SQUIT cm22.eng.umd.edu :Server out of control",
+            Some("Trillian".parse().unwrap()),
+            Command::SQuit {
+                server: "cm22.eng.umd.edu".parse().unwrap(),
+                comment: "Server out of control".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_join() {
+        // Command to join channel #foobar.
+        assert_roundtrip(
+            "JOIN #foobar",
+            None,
+            Command::Join {
+                channels: "#foobar".parse().unwrap(),
+                keys: KeywordList::new(),
+            },
+        );
+        // Command to join channel &foo using key "fubar".
+        assert_roundtrip(
+            "JOIN &foo fubar",
+            None,
+            Command::Join {
+                channels: "&foo".parse().unwrap(),
+                keys: "fubar".parse().unwrap(),
+            },
+        );
+        // Command to join channel #foo using key "fubar" and &bar using no key.
+        assert_roundtrip(
+            "JOIN #foo,&bar fubar",
+            None,
+            Command::Join {
+                channels: "#foo,&bar".parse().unwrap(),
+                keys: "fubar".parse().unwrap(),
+            },
+        );
+        // Command to join channel #foo using key "fubar", and channel #bar using key "foobar".
+        assert_roundtrip(
+            "JOIN #foo,#bar fubar,foobar",
+            None,
+            Command::Join {
+                channels: "#foo,#bar".parse().unwrap(),
+                keys: "fubar,foobar".parse().unwrap(),
+            },
+        );
+        // Command to join channels #foo and #bar.
+        assert_roundtrip(
+            "JOIN #foo,#bar",
+            None,
+            Command::Join {
+                channels: "#foo,#bar".parse().unwrap(),
+                keys: KeywordList::new(),
+            },
+        );
+        // Leave all currently joined channels.
+        assert_roundtrip(
+            "JOIN 0",
+            None,
+            Command::Join {
+                channels: KeywordList::new(),
+                keys: KeywordList::new(),
+            },
+        );
+        // JOIN message from WiZ on channel #Twilight_zone
+        assert_roundtrip(
+            ":WiZ!jto@tolsun.oulu.fi JOIN #Twilight_zone",
+            Some("WiZ!jto@tolsun.oulu.fi".parse().unwrap()),
+            Command::Join {
+                channels: "#Twilight_zone".parse().unwrap(),
+                keys: KeywordList::new(),
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_part() {
+        // Command to leave channel "#twilight_zone"
+        assert_roundtrip(
+            "PART #twilight_zone",
+            None,
+            Command::Part {
+                channels: "#twilight_zone".parse().unwrap(),
+                message: None,
+            },
+        );
+        // Command to leave both channels "&group5" and "#oz-ops".
+        assert_roundtrip(
+            "PART #oz-ops,&group5",
+            None,
+            Command::Part {
+                channels: "#oz-ops,&group5".parse().unwrap(),
+                message: None,
+            },
+        );
+        // User WiZ leaving channel "#playzone" with the message "I lost".
+        assert_roundtrip(
+            ":WiZ!jto@tolsun.oulu.fi PART #playzone :I lost",
+            Some("WiZ!jto@tolsun.oulu.fi".parse().unwrap()),
+            Command::Part {
+                channels: "#playzone".parse().unwrap(),
+                message: Some("I lost".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_channel_mode() {
+        // Command to make #Finnish channel moderated and 'invite-only' with user with a hostname matching *.fi automatically invited.
+        assert_roundtrip(
+            "MODE #Finnish +imI *!*@*.fi",
+            None,
+            Command::ChannelMode {
+                channel: "#Finnish".parse().unwrap(),
+                modes: "+imI *!*@*.fi".to_string(),
+            },
+        );
+        // Command to give 'chanop' privileges to Kilroy on channel #Finnish.
+        assert_roundtrip(
+            "MODE #Finnish +o Kilroy",
+            None,
+            Command::ChannelMode {
+                channel: "#Finnish".parse().unwrap(),
+                modes: "+o Kilroy".to_string(),
+            },
+        );
+        // Command to allow WiZ to speak on #Finnish.
+        assert_roundtrip(
+            "MODE #Finnish +v Wiz",
+            None,
+            Command::ChannelMode {
+                channel: "#Finnish".parse().unwrap(),
+                modes: "+v Wiz".to_string(),
+            },
+        );
+        // Command to remove 'secret' flag from channel #Fins.
+        assert_roundtrip(
+            "MODE #Fins -s",
+            None,
+            Command::ChannelMode {
+                channel: "#Fins".parse().unwrap(),
+                modes: "-s".to_string(),
+            },
+        );
+        // Command to set the channel key to "oulu".
+        assert_roundtrip(
+            "MODE #42 +k oulu",
+            None,
+            Command::ChannelMode {
+                channel: "#42".parse().unwrap(),
+                modes: "+k oulu".to_string(),
+            },
+        );
+        // Command to remove the "oulu" channel key on channel "#42".
+        assert_roundtrip(
+            "MODE #42 -k oulu",
+            None,
+            Command::ChannelMode {
+                channel: "#42".parse().unwrap(),
+                modes: "-k oulu".to_string(),
+            },
+        );
+        // Command to set the limit for the number of users on channel "#eu-opers" to 10.
+        assert_roundtrip(
+            "MODE #eu-opers +l 10",
+            None,
+            Command::ChannelMode {
+                channel: "#eu-opers".parse().unwrap(),
+                modes: "+l 10".to_string(),
+            },
+        );
+        // User "WiZ" removing the limit for the number of users on channel "#eu- opers".
+        assert_roundtrip(
+            "MODE #eu-opers -l",
+            None,
+            Command::ChannelMode {
+                channel: "#eu-opers".parse().unwrap(),
+                modes: "-l".to_string(),
+            },
+        );
+        // Command to list ban masks set for the channel "&oulu".
+        assert_roundtrip(
+            "MODE &oulu +b",
+            None,
+            Command::ChannelMode {
+                channel: "&oulu".parse().unwrap(),
+                modes: "+b".to_string(),
+            },
+        );
+        // Command to prevent all users from joining.
+        assert_roundtrip(
+            "MODE &oulu +b *!*@*",
+            None,
+            Command::ChannelMode {
+                channel: "&oulu".parse().unwrap(),
+                modes: "+b *!*@*".to_string(),
+            },
+        );
+        // Command to prevent any user from a hostname matching *.edu from joining, except if matching *.bu.edu
+        assert_roundtrip(
+            "MODE &oulu +b *!*@*.edu +e *!*@*.bu.edu",
+            None,
+            Command::ChannelMode {
+                channel: "&oulu".parse().unwrap(),
+                modes: "+b *!*@*.edu +e *!*@*.bu.edu".to_string(),
+            },
+        );
+        // Comment to prevent any user from a hostname matching *.edu from joining, except if matching *.bu.edu
+        assert_roundtrip(
+            "MODE #bu +be *!*@*.edu *!*@*.bu.edu",
+            None,
+            Command::ChannelMode {
+                channel: "#bu".parse().unwrap(),
+                modes: "+be *!*@*.edu *!*@*.bu.edu".to_string(),
+            },
+        );
+        // Command to list exception masks set for the channel "#meditation".
+        assert_roundtrip(
+            "MODE #meditation e",
+            None,
+            Command::ChannelMode {
+                channel: "#meditation".parse().unwrap(),
+                modes: "e".to_string(),
+            },
+        );
+        // Command to list invitations masks set for the channel "#meditation".
+        assert_roundtrip(
+            "MODE #meditation I",
+            None,
+            Command::ChannelMode {
+                channel: "#meditation".parse().unwrap(),
+                modes: "I".to_string(),
+            },
+        );
+        // Command to ask who the channel creator for "!12345ircd" is
+        assert_roundtrip(
+            "MODE !12345ircd O",
+            None,
+            Command::ChannelMode {
+                channel: "!12345ircd".parse().unwrap(),
+                modes: "O".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_topic() {
+        // User Wiz setting the topic.
+        assert_roundtrip(
+            ":WiZ!jto@tolsun.oulu.fi TOPIC #test :New topic",
+            Some("WiZ!jto@tolsun.oulu.fi".parse().unwrap()),
+            Command::Topic {
+                channel: "#test".parse().unwrap(),
+                topic: Some("New topic".to_string()),
+            },
+        );
+        // Command to set the topic on #test to "another topic".
+        assert_roundtrip(
+            "TOPIC #test :another topic",
+            None,
+            Command::Topic {
+                channel: "#test".parse().unwrap(),
+                topic: Some("another topic".to_string()),
+            },
+        );
+        // Command to clear the topic on #test.
+        assert_roundtrip(
+            "TOPIC #test :",
+            None,
+            Command::Topic {
+                channel: "#test".parse().unwrap(),
+                topic: Some("".to_string()),
+            },
+        );
+        // Command to check the topic for #test.
+        assert_roundtrip(
+            "TOPIC #test",
+            None,
+            Command::Topic {
+                channel: "#test".parse().unwrap(),
+                topic: None,
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_names() {
+        // Command to list visible users on #twilight_zone and #42
+        assert_roundtrip(
+            "NAMES #twilight_zone,#42",
+            None,
+            Command::Names {
+                channels: "#twilight_zone,#42".parse().unwrap(),
+                target: None,
+            },
+        );
+        // Command to list all visible channels and users
+        assert_roundtrip(
+            "NAMES",
+            None,
+            Command::Names {
+                channels: KeywordList::new(),
+                target: None,
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_list() {
+        // Command to list all channels
+        assert_roundtrip(
+            "LIST",
+            None,
+            Command::List {
+                channels: KeywordList::new(),
+                target: None,
+            },
+        );
+        // Command to list channels #twilight_zone and #42
+        assert_roundtrip(
+            "LIST #twilight_zone,#42",
+            None,
+            Command::List {
+                channels: "#twilight_zone,#42".parse().unwrap(),
+                target: None,
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_invite() {
+        // Message to WiZ when he has been invited by user Angel to channel #Dust
+        assert_roundtrip(
+            ":Angel!wings@irc.org INVITE Wiz #Dust",
+            Some("Angel!wings@irc.org".parse().unwrap()),
+            Command::Invite {
+                nickname: "Wiz".parse().unwrap(),
+                channel: "#Dust".parse().unwrap(),
+            },
+        );
+        // Command to invite WiZ to #Twilight_zone
+        assert_roundtrip(
+            "INVITE Wiz #Twilight_Zone",
+            None,
+            Command::Invite {
+                nickname: "Wiz".parse().unwrap(),
+                channel: "#Twilight_Zone".parse().unwrap(),
+            },
+        );
+    }
+
+    #[test]
+    fn channel_operations_kick() {
+        // Command to kick Matthew from &Melbourne
+        assert_roundtrip(
+            "KICK &Melbourne Matthew",
+            None,
+            Command::Kick {
+                channels: "&Melbourne".parse().unwrap(),
+                users: "Matthew".parse().unwrap(),
+                comment: None,
+            },
+        );
+        // Command to kick John from #Finnish using "Speaking English" as the reason (comment).
+        assert_roundtrip(
+            "KICK #Finnish John :Speaking English",
+            None,
+            Command::Kick {
+                channels: "#Finnish".parse().unwrap(),
+                users: "John".parse().unwrap(),
+                comment: Some("Speaking English".to_string()),
+            },
+        );
+        // KICK message on channel #Finnish from WiZ to remove John from channel
+        assert_roundtrip(
+            ":WiZ!jto@tolsun.oulu.fi KICK #Finnish John",
+            Some("WiZ!jto@tolsun.oulu.fi".parse().unwrap()),
+            Command::Kick {
+                channels: "#Finnish".parse().unwrap(),
+                users: "John".parse().unwrap(),
+                comment: None,
+            },
+        );
+    }
+
+    #[test]
+    fn sending_messages_privmsg() {
+        // Message from Angel to Wiz.
+        assert_roundtrip(
+            ":Angel!wings@irc.org PRIVMSG Wiz :Are you receiving this message ?",
+            Some("Angel!wings@irc.org".parse().unwrap()),
+            Command::Privmsg {
+                recipients: "Wiz".parse().unwrap(),
+                message: "Are you receiving this message ?".parse().unwrap(),
+            },
+        );
+        // Command to send a message to Angel.
+        assert_roundtrip(
+            "PRIVMSG Angel :yes I'm receiving it !",
+            None,
+            Command::Privmsg {
+                recipients: "Angel".parse().unwrap(),
+                message: "yes I'm receiving it !".parse().unwrap(),
+            },
+        );
+        // Command to send a message to a user on server tolsun.oulu.fi with username of "jto".
+        assert_roundtrip(
+            "PRIVMSG jto@tolsun.oulu.fi :Hello !",
+            None,
+            Command::Privmsg {
+                recipients: "jto@tolsun.oulu.fi".parse().unwrap(),
+                message: "Hello !".parse().unwrap(),
+            },
+        );
+        // Message to a user on server irc.stealth.net with username of "kalt", and connected from the host millennium.stealth.net.
+        assert_roundtrip(
+            "PRIVMSG kalt%millennium.stealth.net@irc.stealth.net :Are you a frog?",
+            None,
+            Command::Privmsg {
+                recipients: "kalt%millennium.stealth.net@irc.stealth.net"
+                    .parse()
+                    .unwrap(),
+                message: "Are you a frog?".parse().unwrap(),
+            },
+        );
+        // Message to a user on the local server with username of "kalt", and connected from the host millennium.stealth.net.
+        assert_roundtrip(
+            "PRIVMSG kalt%millennium.stealth.net :Do you like cheese?",
+            None,
+            Command::Privmsg {
+                recipients: "kalt%millennium.stealth.net".parse().unwrap(),
+                message: "Do you like cheese?".parse().unwrap(),
+            },
+        );
+        // Message to the user with nickname Wiz who is connected from the host tolsun.oulu.fi and has the username "jto".
+        assert_roundtrip(
+            "PRIVMSG Wiz!jto@tolsun.oulu.fi :Hello !",
+            None,
+            Command::Privmsg {
+                recipients: "Wiz!jto@tolsun.oulu.fi".parse().unwrap(),
+                message: "Hello !".parse().unwrap(),
+            },
+        );
+        // Message to everyone on a server which has a name matching *.fi.
+        assert_roundtrip(
+            "PRIVMSG $*.fi :Server tolsun.oulu.fi rebooting.",
+            None,
+            Command::Privmsg {
+                recipients: "$*.fi".parse().unwrap(),
+                message: "Server tolsun.oulu.fi rebooting.".parse().unwrap(),
+            },
+        );
+        // Message to all users who come from a host which has a name matching *.edu.
+        assert_roundtrip(
+            "PRIVMSG #*.edu :NSFNet is undergoing work, expect interruptions",
+            None,
+            Command::Privmsg {
+                recipients: "#*.edu".parse().unwrap(),
+                message: "NSFNet is undergoing work, expect interruptions"
+                    .parse()
+                    .unwrap(),
+            },
+        );
+    }
+
+    #[test]
+    fn sending_messages_notice() {
+        // Message from Angel to Wiz.
+        assert_roundtrip(
+            ":Angel!wings@irc.org NOTICE Wiz :Are you receiving this message ?",
+            Some("Angel!wings@irc.org".parse().unwrap()),
+            Command::Notice {
+                recipients: "Wiz".parse().unwrap(),
+                message: "Are you receiving this message ?".parse().unwrap(),
+            },
+        );
+        // Message to all users who come from a host which has a name matching *.edu.
+        assert_roundtrip(
+            "NOTICE #*.edu :NSFNet is undergoing work, expect interruptions",
+            None,
+            Command::Notice {
+                recipients: "#*.edu".parse().unwrap(),
+                message: "NSFNet is undergoing work, expect interruptions"
+                    .parse()
+                    .unwrap(),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_motd() {
+        assert_roundtrip("MOTD", None, Command::Motd { target: None });
+        assert_roundtrip(
+            "MOTD irc.example.com",
+            None,
+            Command::Motd {
+                target: Some("irc.example.com".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_lusers() {
+        assert_roundtrip(
+            "LUSERS",
+            None,
+            Command::LUsers {
+                mask: None,
+                target: None,
+            },
+        );
+        assert_roundtrip(
+            ":irc.example.com LUSERS *.com",
+            Some("irc.example.com".parse().unwrap()),
+            Command::LUsers {
+                mask: Some("*.com".parse().unwrap()),
+                target: None,
+            },
+        );
+        assert_roundtrip(
+            "LUSERS *.com irc.example.com",
+            None,
+            Command::LUsers {
+                mask: Some("*.com".parse().unwrap()),
+                target: Some("irc.example.com".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_version() {
+        assert_roundtrip("VERSION", None, Command::Version { target: None });
+        // Command to check the version of server "tolsun.oulu.fi".
+        assert_roundtrip(
+            "VERSION tolsun.oulu.fi",
+            None,
+            Command::Version {
+                target: Some("tolsun.oulu.fi".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_stats() {
+        assert_roundtrip(
+            "STATS",
+            None,
+            Command::Stats {
+                query: None,
+                target: None,
+            },
+        );
+        // Command to check the command usage for the server you are connected to
+        assert_roundtrip(
+            "STATS m",
+            None,
+            Command::Stats {
+                query: Some("m".parse().unwrap()),
+                target: None,
+            },
+        );
+        assert_roundtrip(
+            "STATS o irc.example.com",
+            None,
+            Command::Stats {
+                query: Some("o".parse().unwrap()),
+                target: Some("irc.example.com".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_links() {
+        assert_roundtrip(
+            "LINKS",
+            None,
+            Command::Links {
+                mask: None,
+                target: None,
+            },
+        );
+        // Command to list all servers which have a name that matches *.au;
+        assert_roundtrip(
+            "LINKS *.au",
+            None,
+            Command::Links {
+                mask: Some("*.au".parse().unwrap()),
+                target: None,
+            },
+        );
+        // Command to list servers matching *.bu.edu as seen by the first server matching *.edu.
+        assert_roundtrip(
+            "LINKS *.edu *.bu.edu",
+            None,
+            Command::Links {
+                mask: Some("*.bu.edu".parse().unwrap()),
+                target: Some("*.edu".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_time() {
+        assert_roundtrip("TIME", None, Command::Time { target: None });
+        // check the time on the server "tolson.oulu.fi"
+        assert_roundtrip(
+            "TIME tolsun.oulu.fi",
+            None,
+            Command::Time {
+                target: Some("tolsun.oulu.fi".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_trace() {
+        assert_roundtrip("TRACE", None, Command::Trace { target: None });
+        // TRACE to a server matching *.oulu.fi
+        assert_roundtrip(
+            "TRACE *.oulu.fi",
+            None,
+            Command::Trace {
+                target: Some("*.oulu.fi".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_admin() {
+        assert_roundtrip("ADMIN", None, Command::Admin { target: None });
+        // request an ADMIN reply from tolsun.oulu.fi
+        assert_roundtrip(
+            "ADMIN tolsun.oulu.fi",
+            None,
+            Command::Admin {
+                target: Some("tolsun.oulu.fi".to_string()),
+            },
+        );
+        // ADMIN request for the server to which the user syrk is connected
+        assert_roundtrip(
+            "ADMIN syrk",
+            None,
+            Command::Admin {
+                target: Some("syrk".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_info() {
+        assert_roundtrip("INFO", None, Command::Info { target: None });
+        // request an INFO reply from csd.bu.edu
+        assert_roundtrip(
+            "INFO csd.bu.edu",
+            None,
+            Command::Info {
+                target: Some("csd.bu.edu".to_string()),
+            },
+        );
+        // request info from the server that Angel is connected to.
+        assert_roundtrip(
+            "INFO Angel",
+            None,
+            Command::Info {
+                target: Some("Angel".to_string()),
+            },
+        );
+        assert_roundtrip(
+            "INFO *.example.com",
+            None,
+            Command::Info {
+                target: Some("*.example.com".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_servlist() {
+        assert_roundtrip(
+            "SERVLIST",
+            None,
+            Command::ServList {
+                mask: None,
+                service_type: None,
+            },
+        );
+        assert_roundtrip(
+            "SERVLIST *dict",
+            None,
+            Command::ServList {
+                mask: Some("*dict".to_string()),
+                service_type: None,
+            },
+        );
+        assert_roundtrip(
+            "SERVLIST * bot",
+            None,
+            Command::ServList {
+                mask: Some("*".to_string()),
+                service_type: Some("bot".to_string()),
+            },
+        );
+    }
+
+    #[test]
+    fn server_queries_and_commands_squery() {
+        // Message to the service with nickname irchelp.
+        assert_roundtrip(
+            "SQUERY irchelp :HELP privmsg",
+            None,
+            Command::SQuery {
+                recipient: "irchelp".parse().unwrap(),
+                message: "HELP privmsg".to_string(),
+            },
+        );
+        // Message to the service with name dict@irc.fr.
+        assert_roundtrip(
+            "SQUERY dict@irc.fr :fr2en blaireau",
+            None,
+            Command::SQuery {
+                recipient: "dict@irc.fr".parse().unwrap(),
+                message: "fr2en blaireau".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn user_based_queries_who() {
+        assert_roundtrip(
+            "WHO",
+            None,
+            Command::Who {
+                mask: None,
+                op_only: false,
+            },
+        );
+        // Command to list all users who match against "*.fi".
+        assert_roundtrip(
+            "WHO *.fi",
+            None,
+            Command::Who {
+                mask: Some("*.fi".to_string()),
+                op_only: false,
+            },
+        );
+        // Command to list all users with a match against "jto*" if they are an operator.
+        assert_roundtrip(
+            "WHO jto* o",
+            None,
+            Command::Who {
+                mask: Some("jto*".to_string()),
+                op_only: true,
+            },
+        );
+    }
+
+    #[test]
+    fn user_based_queries_whois() {
+        // return available user information about nick WiZ
+        assert_roundtrip(
+            "WHOIS wiz",
+            None,
+            Command::WhoIs {
+                target: None,
+                mask: "wiz".to_string(),
+            },
+        );
+        // ask server eff.org for user information  about trillian
+        assert_roundtrip(
+            "WHOIS eff.org trillian",
+            None,
+            Command::WhoIs {
+                target: Some("eff.org".parse().unwrap()),
+                mask: "trillian".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn user_based_queries_whowas() {
+        // return all information in the nick history about nick "WiZ";
+        assert_roundtrip(
+            "WHOWAS Wiz",
+            None,
+            Command::WhoWas {
+                nicknames: "Wiz".parse().unwrap(),
+                count: None,
+                target: None,
+            },
+        );
+        // return at most, the 9 most recent entries in the nick history for "Mermaid";
+        assert_roundtrip(
+            "WHOWAS Mermaid 9",
+            None,
+            Command::WhoWas {
+                nicknames: "Mermaid".parse().unwrap(),
+                count: Some(9),
+                target: None,
+            },
+        );
+        // return the most recent history for "Trillian" from the first server found to match "*.edu".
+        assert_roundtrip(
+            "WHOWAS Trillian 1 *.edu",
+            None,
+            Command::WhoWas {
+                nicknames: "Trillian".parse().unwrap(),
+                count: Some(1),
+                target: Some("*.edu".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn miscellaneous_messages_kill() {
+        assert_roundtrip(
+            "KILL Kenny :It's a trope, okay?",
+            None,
+            Command::Kill {
+                nickname: "Kenny".parse().unwrap(),
+                comment: "It's a trope, okay?".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn miscellaneous_messages_ping() {
+        // Command to send a PING message to server
+        assert_roundtrip(
+            "PING tolsun.oulu.fi",
+            None,
+            Command::Ping {
+                to: Some("tolsun.oulu.fi".parse().unwrap()),
+                from: None,
+            },
+        );
+        // Command from WiZ to send a PING message to server "tolsun.oulu.fi"
+        assert_roundtrip(
+            "PING WiZ tolsun.oulu.fi",
+            None,
+            Command::Ping {
+                to: Some("tolsun.oulu.fi".parse().unwrap()),
+                from: Some("WiZ".parse().unwrap()),
+            },
+        );
+        // Ping message sent by server "irc.funet.fi"
+        assert_roundtrip(
+            "PING :irc.funet.fi",
+            None,
+            Command::Ping {
                 to: None,
-                from: None
-            }),
-        );
-        assert_eq!(
-            "PING myserver".to_string(),
-            String::from(Command::Ping {
-                to: Some("myserver".parse().unwrap()),
-                from: None
-            }),
-        );
-        assert_eq!(
-            "PING me myserver".to_string(),
-            String::from(Command::Ping {
-                to: Some("myserver".parse().unwrap()),
-                from: Some("me".parse().unwrap()),
-            }),
+                from: Some("irc.funet.fi".parse().unwrap()),
+            },
         );
     }
 
     #[test]
-    fn string_from_pong() {
-        assert_eq!(
-            "PONG me".to_string(),
-            String::from(Command::Pong {
-                from: "me".parse().unwrap(),
+    fn miscellaneous_messages_pong() {
+        assert_roundtrip(
+            "PONG irc.example.com",
+            None,
+            Command::Pong {
                 to: None,
-            }),
+                from: "irc.example.com".parse().unwrap(),
+            },
         );
-        assert_eq!(
-            "PONG me myserver".to_string(),
-            String::from(Command::Pong {
-                from: "me".parse().unwrap(),
-                to: Some("myserver".parse().unwrap()),
-            }),
-        );
-    }
-
-    #[test]
-    fn pass_from_string() {
-        assert_eq!(
-            Ok(Command::Pass {
-                password: "mysecretpass".to_string()
-            }),
-            "PASS mysecretpass".parse::<Command>()
+        // PONG message from csd.bu.edu to tolsun.oulu.fi
+        assert_roundtrip(
+            "PONG csd.bu.edu tolsun.oulu.fi",
+            None,
+            Command::Pong {
+                to: Some("tolsun.oulu.fi".parse().unwrap()),
+                from: "csd.bu.edu".parse().unwrap(),
+            },
         );
     }
 
     #[test]
-    fn nick_from_string() {
-        assert_eq!(
-            Ok(Command::Nick {
-                nickname: "somebody".parse().unwrap(),
-            }),
-            "NICK somebody".parse::<Command>()
+    fn miscellaneous_messages_error() {
+        // ERROR message to the other server which caused this error.
+        assert_roundtrip(
+            "ERROR :Server *.fi already exists",
+            None,
+            Command::Error {
+                message: "Server *.fi already exists".to_string(),
+            },
+        );
+        // Same ERROR message as above but sent to user WiZ on the other server.
+        assert_roundtrip(
+            "NOTICE WiZ :ERROR from csd.bu.edu -- Server *.fi already exists",
+            None,
+            Command::Notice {
+                recipients: "WiZ".parse().unwrap(),
+                message: "ERROR from csd.bu.edu -- Server *.fi already exists".to_string(),
+            },
         );
     }
 
     #[test]
-    fn user_from_string() {
-        assert!("USER pjohnson 0 *".parse::<Command>().is_err());
-        assert!("USER pjohnson 0 * Potato Johnson"
-            .parse::<Command>()
-            .is_err());
-
-        assert_eq!(
-            Ok(Command::User {
-                username: "pjohnson".parse().unwrap(),
-                mode: 0,
-                realname: "Potato Johnson".to_string()
-            }),
-            "USER pjohnson 0 * :Potato Johnson".parse::<Command>()
+    fn optional_features_away() {
+        assert_roundtrip("AWAY", None, Command::Away { message: None });
+        // Command to set away message to "Gone to lunch.  Back in 5".
+        assert_roundtrip(
+            "AWAY :Gone to lunch.  Back in 5",
+            None,
+            Command::Away {
+                message: Some("Gone to lunch.  Back in 5".to_string()),
+            },
         );
     }
 
     #[test]
-    fn ping_from_string() {
-        assert_eq!(
-            Ok(Command::Ping {
-                to: None,
-                from: None
-            }),
-            "PING".parse::<Command>()
-        );
-        assert_eq!(
-            Ok(Command::Ping {
-                to: None,
-                from: Some("spudly".parse().unwrap())
-            }),
-            "PING :spudly".parse::<Command>()
-        );
-        assert_eq!(
-            Ok(Command::Ping {
-                to: Some("irc.example.com".parse().unwrap()),
-                from: None
-            }),
-            "PING irc.example.com".parse::<Command>()
-        );
-        assert_eq!(
-            Ok(Command::Ping {
-                to: Some("irc.example.com".parse().unwrap()),
-                from: Some("spudly".parse().unwrap())
-            }),
-            "PING spudly irc.example.com".parse::<Command>()
-        );
-        assert!("PING a b c".parse::<Command>().is_err());
+    fn optional_features_rehash() {
+        // message from user with operator status to server asking it to reread its configuration file.
+        assert_roundtrip("REHASH", None, Command::Rehash);
     }
 
     #[test]
-    fn pong_from_string() {
-        assert_eq!(
-            Ok(Command::Pong {
-                to: None,
-                from: "me".parse().unwrap()
-            }),
-            "PONG me".parse::<Command>()
+    fn optional_features_die() {
+        // no parameters required
+        assert_roundtrip("DIE", None, Command::Die);
+    }
+
+    #[test]
+    fn optional_features_restart() {
+        // no parameters required
+        assert_roundtrip("RESTART", None, Command::Restart);
+    }
+
+    #[test]
+    fn optional_features_summon() {
+        // summon user jto on the server's host
+        assert_roundtrip(
+            "SUMMON jto",
+            None,
+            Command::Summon {
+                user: "jto".parse().unwrap(),
+                target: None,
+                channel: None,
+            },
         );
-        assert_eq!(
-            Ok(Command::Pong {
-                to: Some("myserver".parse().unwrap()),
-                from: "me".parse().unwrap()
-            }),
-            "PONG me myserver".parse::<Command>()
+        // summon user jto on the host which a server named "tolsun.oulu.fi" is running.
+        assert_roundtrip(
+            "SUMMON jto tolsun.oulu.fi",
+            None,
+            Command::Summon {
+                user: "jto".parse().unwrap(),
+                target: Some("tolsun.oulu.fi".parse().unwrap()),
+                channel: None,
+            },
         );
-        assert!("PONG".parse::<Command>().is_err());
-        assert!("PONG a b c".parse::<Command>().is_err());
+        assert_roundtrip(
+            "SUMMON spudly irc.example.com #potato",
+            None,
+            Command::Summon {
+                user: "spudly".parse().unwrap(),
+                target: Some("irc.example.com".parse().unwrap()),
+                channel: Some("#potato".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn optional_features_users() {
+        assert_roundtrip("USERS", None, Command::Users { target: None });
+        // request a list of users logged in on server eff.org
+        assert_roundtrip(
+            "USERS eff.org",
+            None,
+            Command::Users {
+                target: Some("eff.org".parse().unwrap()),
+            },
+        );
+    }
+
+    #[test]
+    fn optional_features_wallops() {
+        // WALLOPS message from csd.bu.edu announcing a CONNECT message it received from Joshua and acted upon.
+        assert_roundtrip(
+            ":csd.bu.edu WALLOPS :Connect '*.uiuc.edu 6667' from Joshua",
+            Some("csd.bu.edu".parse().unwrap()),
+            Command::WallOps {
+                message: "Connect '*.uiuc.edu 6667' from Joshua".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn optional_features_userhost() {
+        // USERHOST request for information on nicks "Wiz", "Michael", and "syrk"
+        assert_roundtrip(
+            "USERHOST Wiz Michael syrk",
+            None,
+            Command::UserHost {
+                nicknames: "Wiz,Michael,syrk".parse().unwrap(),
+            },
+        );
+    }
+
+    #[test]
+    fn optional_features_ison() {
+        // Sample ISON request for 7 nicks.
+        assert_roundtrip(
+            "ISON phone trillian WiZ jarlek Avalon Angel Monstah syrk",
+            None,
+            Command::IsOn {
+                nicknames: "phone,trillian,WiZ,jarlek,Avalon,Angel,Monstah,syrk"
+                    .parse()
+                    .unwrap(),
+            },
+        );
     }
 }

--- a/src/connection/message/mod.rs
+++ b/src/connection/message/mod.rs
@@ -66,9 +66,9 @@ mod test_message {
         assert_eq!(
             Ok(Message {
                 sender: Some("me".parse().unwrap()),
-                body: MessageBody::Reply(ReplyType::PrvWelcome, "Hi there".to_string())
+                body: MessageBody::Reply(ReplyType::PrvWelcome, ":Hi there".parse().unwrap())
             }),
-            ":me 001 Hi there\r\n".parse::<Message>()
+            ":me 001 :Hi there\r\n".parse::<Message>()
         );
         assert_eq!(
             Ok(Message {
@@ -84,10 +84,10 @@ mod test_message {
     #[test]
     fn string() {
         assert_eq!(
-            ":me 001 Hi there".to_string(),
+            ":me 001 :Hi there".to_string(),
             String::from(Message {
                 sender: Some("me".parse().unwrap()),
-                body: MessageBody::Reply(ReplyType::PrvWelcome, "Hi there".to_string())
+                body: MessageBody::Reply(ReplyType::PrvWelcome, ":Hi there".parse().unwrap())
             })
         );
         assert_eq!(
@@ -105,7 +105,7 @@ mod test_message {
 #[derive(PartialEq, Debug)]
 pub enum MessageBody {
     Command(Command),
-    Reply(ReplyType, String),
+    Reply(ReplyType, MessageParams),
 }
 
 impl FromStr for MessageBody {
@@ -118,10 +118,10 @@ impl FromStr for MessageBody {
                 if let Some(index) = raw.find(' ') {
                     Ok(MessageBody::Reply(
                         raw[..index].parse()?,
-                        raw[index + 1..].to_string(),
+                        raw[index + 1..].parse()?,
                     ))
                 } else {
-                    Ok(MessageBody::Reply(raw.parse()?, String::new()))
+                    Ok(MessageBody::Reply(raw.parse()?, MessageParams::new()))
                 }
             }
             _ => Err(ParseError::new("MessageBody")),
@@ -159,19 +159,25 @@ mod test_message_body {
     #[test]
     fn valid() {
         assert_eq!(
-            Ok(MessageBody::Reply(ReplyType::PrvWelcome, "".to_string())),
+            Ok(MessageBody::Reply(
+                ReplyType::PrvWelcome,
+                "".parse().unwrap()
+            )),
             "001".parse::<MessageBody>()
         );
         assert_eq!(
-            Ok(MessageBody::Reply(ReplyType::PrvWelcome, "".to_string())),
+            Ok(MessageBody::Reply(
+                ReplyType::PrvWelcome,
+                "".parse().unwrap()
+            )),
             "001 ".parse::<MessageBody>()
         );
         assert_eq!(
             Ok(MessageBody::Reply(
                 ReplyType::PrvWelcome,
-                "Hi there".to_string()
+                ":Hi there".parse().unwrap()
             )),
-            "001 Hi there".parse::<MessageBody>()
+            "001 :Hi there".parse::<MessageBody>()
         );
         assert_eq!(
             Ok(MessageBody::Command(Command::Nick {
@@ -184,10 +190,10 @@ mod test_message_body {
     #[test]
     fn string() {
         assert_eq!(
-            "001 Hi there".to_string(),
+            "001 :Hi there".to_string(),
             String::from(MessageBody::Reply(
                 ReplyType::PrvWelcome,
-                "Hi there".to_string()
+                ":Hi there".parse().unwrap()
             ))
         );
         assert_eq!(

--- a/src/connection/message/mod.rs
+++ b/src/connection/message/mod.rs
@@ -212,8 +212,8 @@ pub struct MessageParams {
 }
 
 impl MessageParams {
-    pub fn new() -> MessageParams {
-        MessageParams {
+    pub fn new() -> Self {
+        Self {
             args: Vec::new(),
             has_space: false,
         }
@@ -236,6 +236,13 @@ impl MessageParams {
 
     pub fn get(&self, index: usize) -> Option<&String> {
         self.args.get(index)
+    }
+
+    pub fn to_string_with_prefix(self, prefix: &str) -> String {
+        let mut result = String::from(prefix);
+        result.push(' ');
+        result.push_str(&String::from(self));
+        result
     }
 }
 
@@ -290,6 +297,7 @@ impl FromStr for MessageParams {
 impl From<MessageParams> for String {
     fn from(command_args: MessageParams) -> String {
         let mut result = String::new();
+        let mut last_elment_is_empty = false;
 
         for arg in command_args.args {
             if !result.is_empty() {
@@ -298,9 +306,30 @@ impl From<MessageParams> for String {
             if arg.contains(' ') {
                 result.push(':');
             }
-            result.push_str(&arg);
+
+            if arg == "" {
+                result.push('*');
+                last_elment_is_empty = true;
+            } else {
+                result.push_str(&arg);
+                last_elment_is_empty = false;
+            }
+        }
+        if last_elment_is_empty {
+            result.pop();
+            result.push(':');
         }
         result
+    }
+}
+
+impl From<Vec<String>> for MessageParams {
+    fn from(original: Vec<String>) -> Self {
+        let mut message_params = Self::new();
+        for arg in original.into_iter() {
+            message_params.push(arg).unwrap();
+        }
+        message_params
     }
 }
 

--- a/src/connection/message/reply.rs
+++ b/src/connection/message/reply.rs
@@ -1,11 +1,11 @@
-use super::ParseError;
+use super::{MessageParams, ParseError};
 use std::result::Result;
 use std::str::FromStr;
 
 #[derive(PartialEq, Debug)]
 pub struct Reply {
     pub reply_type: ReplyType,
-    pub reply_message: String,
+    pub params: MessageParams,
 }
 
 impl FromStr for Reply {
@@ -19,7 +19,7 @@ impl FromStr for Reply {
         if let Ok(reply_type) = raw[..3].parse() {
             Ok(Reply {
                 reply_type,
-                reply_message: raw[3..].to_string(),
+                params: raw[3..].parse()?,
             })
         } else {
             Err(ParseError::new("Reply"))
@@ -31,7 +31,7 @@ impl From<Reply> for String {
     fn from(reply: Reply) -> String {
         let mut reply_text = String::from(reply.reply_type);
         reply_text.push(' ');
-        reply_text.push_str(&reply.reply_message);
+        reply_text.push_str(&String::from(reply.params));
         reply_text
     }
 }
@@ -492,11 +492,7 @@ mod tests {
 
     #[test]
     fn all_values_in_range() {
-        for number in 1..=599 {
-            if let 100..=199 = number {
-                continue;
-            }
-
+        for number in (1..=99).chain(200..=599) {
             let number_formatted = format!("{:0>3}", number);
             assert_eq!(
                 number_formatted,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,5 +1,5 @@
 pub use self::entity::{Nickname, Sender, Username};
-pub use self::message::{Command, Message, MessageBody, Reply, ReplyType};
+pub use self::message::{Command, Message, MessageBody, MessageParams, Reply, ReplyType};
 use std::error::Error;
 use std::fmt;
 use std::io;

--- a/src/connection/syntax/keyword_list.rs
+++ b/src/connection/syntax/keyword_list.rs
@@ -12,6 +12,10 @@ impl<T: FromStr + Into<String>> KeywordList<T> {
     pub fn push(&mut self, element: T) {
         self.0.push(element)
     }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 impl<T: FromStr + Into<String>> FromStr for KeywordList<T> {


### PR DESCRIPTION
This more or less completes the parsing and rendering of commands. A few fields still improperly parse to string rather than a more descriptive type, but all of the implemented commands can now be round-tripped.

Also added all examples from RFC 2812 as tests, which makes that file into a beast.