### PR TITLE
Rename project and update README.md

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,13 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crikey-irc"
+version = "0.1.0"
+dependencies = [
+ "pipe 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,13 +34,6 @@ dependencies = [
  "autocfg 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "irustc_bot"
-version = "0.1.0"
-dependencies = [
- "pipe 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "irustc_bot"
+name = "crikey-irc"
 version = "0.1.0"
 authors = ["Mikkel Paulson <git@email.mikkel.ca>"]
 edition = "2018"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.45-alpine
 
-WORKDIR /usr/src/irustc-bot
+WORKDIR /usr/src/crikey-irc
 
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,16 @@ services:
     #ports:
     #  - 6667
 
-  irustc-bot:
+  crikey-irc:
     build:
       context: .
     depends_on:
       - irc-server
     volumes:
-      - ./src:/usr/src/irustc-bot/src
-      - ./tests:/usr/src/irustc-bot/tests
-      - ./Cargo.lock:/usr/src/irustc-bot/Cargo.lock
-      - ./Cargo.toml:/usr/src/irustc-bot/Cargo.toml
+      - ./src:/usr/src/crikey-irc/src
+      - ./tests:/usr/src/crikey-irc/tests
+      - ./Cargo.lock:/usr/src/crikey-irc/Cargo.lock
+      - ./Cargo.toml:/usr/src/crikey-irc/Cargo.toml
     command:
       - cargo
       - run

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use irustc_bot::run;
+use crikey_irc::run;
 use std::env;
 use std::io;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub fn connect<A: net::ToSocketAddrs>(addr: A) -> (Client, Server) {
 
     // Flush client auth and respond with boilerplate welcome text
     server.truncate();
-    server.write_line(":irc.example.net 001 spudly :Welcome to the Internet Relay Network baz!~pjohnson@ircbot_irustc-bot_run_33951ac1d023.ircbot_default");
+    server.write_line(":irc.example.net 001 spudly :Welcome to the Internet Relay Network baz!~pjohnson@ircbot_crikey-irc_run_33951ac1d023.ircbot_default");
     server.write_line(":irc.example.net 002 spudly :Your host is irc.example.net, running version ngircd-23 (x86_64/alpine/linux-musl)");
     server.write_line(":irc.example.net 003 spudly :This server has been started Fri Aug 21 2020 at 03:21:11 (UTC)");
     server.write_line(":irc.example.net 004 spudly irc.example.net ngircd-23 abBcCFiIoqrRswx abehiIklmMnoOPqQrRstvVz");
@@ -46,7 +46,7 @@ impl Client {
     pub fn new<A: net::ToSocketAddrs>(addr: &A) -> Client {
         let server_ip: String = addr.to_socket_addrs().unwrap().next().unwrap().to_string();
 
-        let child = process::Command::new("target/debug/irustc_bot")
+        let child = process::Command::new("target/debug/crikey-irc")
             .arg(&server_ip)
             .stdin(process::Stdio::null())
             .stdout(process::Stdio::null())


### PR DESCRIPTION
Updates the project name from the uninspiring `irustc-bot` to `crikey-irc`. Also updates the readme file with a more accurate picture of the current state of development and roadmap.